### PR TITLE
Update deprecated tests as filters

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Disable password login
   lineinfile: dest={{ sshd_config }} regexp="^#?PasswordAuthentication" line="PasswordAuthentication no"
-  when: add_identity_key|success and not add_identity_key|skipped
+  when: add_identity_key is success and not add_identity_key is skipped
   notify: restart sshd
 
 - name: Enable PAM


### PR DESCRIPTION
Ansible 2.5 gives:

[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|success` instead use `result is success`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.