### PR TITLE
improved the regexp for disabling password login

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
   notify: restart sshd
 
 - name: Disable password login
-  lineinfile: dest={{ sshd_config }} regexp="^#?PasswordAuthentication" line="PasswordAuthentication no"
+  lineinfile: dest={{ sshd_config }} regexp="^(#\s*)?PasswordAuthentication " line="PasswordAuthentication no"
   when: add_identity_key is success and not add_identity_key is skipped
   notify: restart sshd
 


### PR DESCRIPTION
By default `PasswordAuthentication` is:
```
# PasswordAuthentication yes
``` 
Regexp like `^(#\s*)?PasswordAuthentication ` handles all possible variants and skip mention in comments:
```
# Set this to 'yes' to enable PAM authentication, account processing,
# and session processing. If this is enabled, PAM authentication will
# be allowed through the ChallengeResponseAuthentication and
# PasswordAuthentication.  Depending on your PAM configuration,
# PAM authentication via ChallengeResponseAuthentication may bypass
# the setting of "PermitRootLogin without-password".
# If you just want the PAM account and session checks to run without
# PAM authentication, then enable this but set PasswordAuthentication
# and ChallengeResponseAuthentication to 'no'.
```