### PR TITLE
Rename success to succeeded

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Disable password login
   lineinfile: dest={{ sshd_config }} regexp="^(#\s*)?PasswordAuthentication " line="PasswordAuthentication no"
-  when: add_identity_key is success and not add_identity_key is skipped
+  when: add_identity_key is succeeded and not add_identity_key is skipped
   notify: restart sshd
 
 - name: Enable PAM


### PR DESCRIPTION
When running this role with Ansible 2.9.1 this error is thrown

```
fatal: [nas.shepherdjerred.com]: FAILED! => {"msg": "The conditional check 'add_identity_key|success and not add_identity_key|skipped' failed. The error was: template error while templating string: no filter named 'success'. String: {% if add_identity_key|success and not add_identity_key|skipped %} True {% else %} False {% endif %}\n\nThe error appears to be in '/Users/jerred/.ansible/roles/vitalk.secure-ssh/tasks/main.yml': line 16, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Disable password login\n  ^ here\n"}
```

It looks like succeed [is the preferred tense](https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html) now. The docs state that the two are interchangeable, but by changing the tense I was able to use the role.