### PR TITLE
Updating Syntax to avoid string quoting bug

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,28 +1,28 @@
 ---
 - name: Add identity key to authorized keys on host
   authorized_key: 
-    user: {{ ssh_user }}
+    user: "{{ ssh_user }}"
     key: "{{ lookup('file', ssh_identity_key) }}"
   register: add_identity_key
   when: ssh_identity_key is defined and ssh_user is defined
 
 - name: Disable empty password login
   lineinfile: 
-    dest: {{ sshd_config }} 
+    dest: "{{ sshd_config }}" 
     regexp: '^#?PermitEmptyPasswords' 
     line: 'PermitEmptyPasswords no'
   notify: restart sshd
 
 - name: Disable remote root login
   lineinfile: 
-    dest: {{ sshd_config }} 
+    dest: "{{ sshd_config }}" 
     regexp: '^#?PermitRootLogin' 
     line: 'PermitRootLogin no'
   notify: restart sshd
 
 - name: Disable password login
   lineinfile: 
-    dest: {{ sshd_config }} 
+    dest: "{{ sshd_config }}" 
     regexp: '^(#\s*)?PasswordAuthentication '
     line: 'PasswordAuthentication no'
   when: 
@@ -32,7 +32,7 @@
 
 - name: Enable PAM
   lineinfile: 
-    dest: {{ sshd_config }} 
+    dest: "{{ sshd_config }}" 
     regexp: '^#?UsePAM' 
     line: 'UsePAM yes'
   notify: restart sshd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,38 @@
 ---
 - name: Add identity key to authorized keys on host
-  authorized_key: user={{ ssh_user }}
-    key="{{ lookup('file', ssh_identity_key) }}"
+  authorized_key: 
+    user: {{ ssh_user }}
+    key: "{{ lookup('file', ssh_identity_key) }}"
   register: add_identity_key
   when: ssh_identity_key is defined and ssh_user is defined
 
 - name: Disable empty password login
-  lineinfile: dest={{ sshd_config }} regexp="^#?PermitEmptyPasswords" line="PermitEmptyPasswords no"
+  lineinfile: 
+    dest: {{ sshd_config }} 
+    regexp: "^#?PermitEmptyPasswords" 
+    line: "PermitEmptyPasswords no"
   notify: restart sshd
 
 - name: Disable remote root login
-  lineinfile: dest={{ sshd_config }} regexp="^#?PermitRootLogin" line="PermitRootLogin no"
+  lineinfile: 
+    dest: {{ sshd_config }} 
+    regexp: "^#?PermitRootLogin" 
+    line: "PermitRootLogin no"
   notify: restart sshd
 
 - name: Disable password login
-  lineinfile: dest={{ sshd_config }} regexp="^(#\s*)?PasswordAuthentication " line="PasswordAuthentication no"
-  when: add_identity_key is succeeded and not add_identity_key is skipped
+  lineinfile: 
+    dest: {{ sshd_config }} 
+    regexp: "^(#\s*)?PasswordAuthentication " 
+    line: "PasswordAuthentication no"
+  when: 
+    - add_identity_key is succeeded 
+    - not add_identity_key is skipped
   notify: restart sshd
 
 - name: Enable PAM
-  lineinfile: dest={{ sshd_config }} regexp="^#?UsePAM" line="UsePAM yes"
+  lineinfile: 
+    dest: {{ sshd_config }} 
+    regexp: "^#?UsePAM" 
+    line: "UsePAM yes"
   notify: restart sshd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,22 +9,22 @@
 - name: Disable empty password login
   lineinfile: 
     dest: {{ sshd_config }} 
-    regexp: "^#?PermitEmptyPasswords" 
-    line: "PermitEmptyPasswords no"
+    regexp: '^#?PermitEmptyPasswords' 
+    line: 'PermitEmptyPasswords no'
   notify: restart sshd
 
 - name: Disable remote root login
   lineinfile: 
     dest: {{ sshd_config }} 
-    regexp: "^#?PermitRootLogin" 
-    line: "PermitRootLogin no"
+    regexp: '^#?PermitRootLogin' 
+    line: 'PermitRootLogin no'
   notify: restart sshd
 
 - name: Disable password login
   lineinfile: 
     dest: {{ sshd_config }} 
-    regexp: "^(#\s*)?PasswordAuthentication " 
-    line: "PasswordAuthentication no"
+    regexp: '^(#\s*)?PasswordAuthentication '
+    line: 'PasswordAuthentication no'
   when: 
     - add_identity_key is succeeded 
     - not add_identity_key is skipped
@@ -33,6 +33,6 @@
 - name: Enable PAM
   lineinfile: 
     dest: {{ sshd_config }} 
-    regexp: "^#?UsePAM" 
-    line: "UsePAM yes"
+    regexp: '^#?UsePAM' 
+    line: 'UsePAM yes'
   notify: restart sshd


### PR DESCRIPTION
I was hitting this error, with ansible 2.9.6 running on Ubuntu 20.04 and pushing to a 20.04 machine.
```
fatal: [redacted]: FAILED! => {"msg": "The conditional check 'add_identity_key|success and not add_identity_key|skipped' failed. The error was: template error while templating string: no filter named 'success'. String: {% if add_identity_key|success and not add_identity_key|skipped %} True {% else %} False {% endif %}\n\nThe error appears to be in '/home/redacted/.ansible/roles/ansible-secure-ssh/tasks/main.yml': line 16, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Disable password login\n  ^ here\n"}
```
I went through and updated the syntax to match the recent docs. I think the error came from the regex line using double quotes which then tried to escape the `\s` in the regex. After correcting for that ansible complained that the variable usage wasn't in double quotes so updated that too.

Confirmed working now on 20.04 